### PR TITLE
Use the correct config for hamcmd

### DIFF
--- a/inotify-spamlearn.py
+++ b/inotify-spamlearn.py
@@ -18,7 +18,7 @@ def getconfig():
         spam_dir = config.get('paths', 'spam_dir')
         ham_dir = config.get('paths', 'ham_dir')
         spamcmd = config.get('spam', 'spamcmd')
-        hamcmd = config.get('spam', 'spamcmd')
+        hamcmd = config.get('spam', 'hamcmd')
         delete = config.getboolean('mode', 'delete')
         scan = config.getboolean('mode', 'scan')
         oneshot = config.getboolean('mode', 'oneshot')


### PR DESCRIPTION
Hi there!

It seems like the script uses the spamcmd for both learning spam and ham. This PR corrects the getconfig for the hamcmd.